### PR TITLE
Updated mass-updator because nx changed its outputs property when migrating to current version

### DIFF
--- a/libs/architect/src/executors/mass-updator/executor.ts
+++ b/libs/architect/src/executors/mass-updator/executor.ts
@@ -38,18 +38,18 @@ export default async function runExecutor(
       : options.replacements;
 
   for (const directory of directories) {
+    const pathToDirectory = path.join(
+      context.root,
+      context.target.outputs[0].replace('{workspaceRoot}/', ''),
+      directory
+    );
     const stream = fg.stream([options.glob], {
-      cwd: path.join(context.root, context.target.outputs[0], directory),
+      cwd: pathToDirectory,
       ignore: ['**/node_modules']
     });
 
     for await (const entry of stream) {
-      const filePath: string = path.join(
-        context.root,
-        context.target.outputs[0],
-        directory,
-        entry as string
-      );
+      const filePath: string = path.join(pathToDirectory, entry as string);
 
       const fileContent: string = await fs.readFile(filePath, {
         encoding: 'utf8'
@@ -73,9 +73,7 @@ export default async function runExecutor(
           options.suffix + '.' + extension
         );
         const duplicateFilePath: string = path.join(
-          context.root,
-          context.target.outputs[0],
-          directory,
+          pathToDirectory,
           suffixedFilename
         );
 

--- a/libs/ngx-dsfr/package.json
+++ b/libs/ngx-dsfr/package.json
@@ -1,11 +1,4 @@
 {
   "name": "@betagouv/ngx-dsfr",
-  "version": "0.0.1",
-  "peerDependencies": {
-    "@angular/common": "^13.3.0",
-    "@angular/core": "^13.3.0"
-  },
-  "dependencies": {
-    "tslib": "^2.3.0"
-  }
+  "version": "0.0.4"
 }


### PR DESCRIPTION
With this, I'm reporting the changes I've made on my _local_ copy of `master`, in order to be able to publish a workable version of `ngx-dsfr` to NPM, to the `develop` branch.